### PR TITLE
update rust wasm env & add local python virtual env in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ pkg/
 */scripts/*
 .VSCodeCounter/
 *.pyc
+venv/

--- a/README.cn.md
+++ b/README.cn.md
@@ -117,6 +117,9 @@ $pip install probing
 `probing` 构建时依赖`trunk`工具，可通过如下命令安装，若已经安装可以跳过此步：
 ```shell
 cargo install trunk
+
+# 安装 wasm-bindgen-cli 工具
+cargo install --locked wasm-bindgen-cli
 ```
 构建环境准备就绪后，可以通过`make`命令来完成构建
 ```shell

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ $pip install probing
 `probing` 构建时依赖`trunk`工具，可通过如下命令安装，若已经安装可以跳过此步：
 ```shell
 cargo install trunk
+
+# 安装 wasm-bindgen-cli 工具
+cargo install --locked wasm-bindgen-cli
 ```
 构建环境准备就绪后，可以通过`make`命令来完成构建
 ```shell


### PR DESCRIPTION
# 补充README.md

首次编译时出现的 wasm-bindgen-cli 环境缺失, 补充rust环境安装

![截图 2024-11-04 14-45-32](https://github.com/user-attachments/assets/7f74b4a9-b595-4dd7-9e84-fc3eab66616a)

# 增加本地python虚拟环境文件夹

针对服务器有多个版本python环境情况, 增加本地**venv**路径到.gitignore
