### PR TITLE
Add import hook functionality with callback registration and testing

### DIFF
--- a/python/probing/__init__.py
+++ b/python/probing/__init__.py
@@ -45,6 +45,8 @@ def init():
 
 init()
 
+import probing.import_hook
+
 
 def query(sql: str) -> "DataFrame":  # type: ignore
     import sys

--- a/python/probing/import_hook.py
+++ b/python/probing/import_hook.py
@@ -1,0 +1,115 @@
+import sys
+import importlib.abc
+import importlib.util
+
+# Mapping from module names to callback functions
+register = {}
+# Record modules that have been triggered
+triggered = {}
+
+
+class ProbingLoader(importlib.abc.Loader):
+    """Custom loader that executes callbacks immediately after module loading"""
+
+    def __init__(self, original_loader, fullname):
+        self.original_loader = original_loader
+        self.fullname = fullname
+
+    def create_module(self, spec):
+        # Delegate module creation to the original loader
+        return (
+            self.original_loader.create_module(spec)
+            if hasattr(self.original_loader, "create_module")
+            else None
+        )
+
+    def exec_module(self, module):
+        # First let the original loader execute the module
+        if hasattr(self.original_loader, "exec_module"):
+            self.original_loader.exec_module(module)
+        elif hasattr(self.original_loader, "load_module"):
+            self.original_loader.load_module(self.fullname)
+
+        # After module execution, immediately trigger the callback
+        if self.fullname in register and self.fullname not in triggered:
+            triggered[self.fullname] = True
+            try:
+                register[self.fullname](module)
+            except Exception as e:
+                print(f"Error in callback for {self.fullname}: {e}")
+
+
+class ProbingFinder(importlib.abc.MetaPathFinder):
+    """Custom finder for intercepting module imports and wrapping loaders"""
+
+    def __init__(self):
+        # Store original finders to restore the import chain
+        self.original_meta_path = list(sys.meta_path)
+
+    def find_spec(self, fullname, path, target=None):
+        # If not a module we're interested in, skip it
+        if fullname not in register:
+            return None
+
+        # Avoid recursive calls
+        if fullname in sys._ProbingFinder_in_progress:
+            return None
+
+        sys._ProbingFinder_in_progress.add(fullname)
+        try:
+            # Temporarily remove self to avoid recursion
+            sys.meta_path = [
+                f for f in self.original_meta_path if not isinstance(f, ProbingFinder)
+            ]
+
+            # Use original finders to find the module
+            spec = importlib.util.find_spec(fullname)
+
+            # Restore meta_path
+            sys.meta_path = list(self.original_meta_path)
+
+            # If module is found, wrap its loader
+            if spec is not None and spec.loader is not None:
+                loader = ProbingLoader(spec.loader, fullname)
+                spec.loader = loader
+
+            return spec
+        finally:
+            sys._ProbingFinder_in_progress.remove(fullname)
+            # Always restore meta_path
+            sys.meta_path = list(self.original_meta_path)
+
+
+def register_module_callback(module_name, callback):
+    """Register callback function for module import"""
+    register[module_name] = callback
+
+    # If the module is already imported, execute the callback immediately
+    if module_name in sys.modules and module_name not in triggered:
+        try:
+            triggered[module_name] = True
+            callback(sys.modules[module_name])
+        except Exception as e:
+            print(f"Error executing callback for {module_name}: {e}")
+
+
+# Initialize recursion protection set
+if not hasattr(sys, "_ProbingFinder_in_progress"):
+    sys._ProbingFinder_in_progress = set()
+
+
+# Install import hook
+def install():
+    # Ensure it's only installed once
+    for finder in sys.meta_path:
+        if isinstance(finder, ProbingFinder):
+            return finder
+
+    # Create and install the hook
+    finder = ProbingFinder()
+    sys.meta_path.insert(0, finder)
+    return finder
+
+
+# Automatically install the hook
+finder = install()

--- a/tests/test_import_hook.py
+++ b/tests/test_import_hook.py
@@ -1,0 +1,86 @@
+import sys
+import unittest
+import os
+import tempfile
+
+# Import the module we're testing
+from probing import import_hook
+
+class TestImportHook(unittest.TestCase):
+    def setUp(self):
+        # Clear any previous registrations for clean testing
+        import_hook.register.clear()
+        import_hook.triggered.clear()
+        
+        # Create a temporary directory for test modules
+        self.temp_dir = tempfile.mkdtemp()
+        sys.path.insert(0, self.temp_dir)
+        
+        # Create a test module
+        with open(os.path.join(self.temp_dir, 'test_module.py'), 'w') as f:
+            f.write('TEST_CONSTANT = "Hello from test module"\n')
+        
+    def tearDown(self):
+        # Remove temp directory from path and clean up
+        sys.path.remove(self.temp_dir)
+        
+        # Remove test modules from sys.modules
+        for module_name in list(sys.modules.keys()):
+            if module_name.startswith('test_module'):
+                del sys.modules[module_name]
+    
+    def test_import_hook_new_module(self):
+        """Test callback execution when importing a new module."""
+        callback_executed = []
+        
+        def my_callback(module):
+            callback_executed.append(True)
+            self.assertEqual(module.TEST_CONSTANT, "Hello from test module")
+        
+        # Register callback for a module that hasn't been imported yet
+        import_hook.register_module_callback('test_module', my_callback)
+        
+        # Now import the module - should trigger the callback
+        import test_module
+        
+        self.assertTrue(callback_executed)
+        self.assertIn('test_module', import_hook.triggered)
+    
+    def test_already_imported_module(self):
+        """Test callback execution for an already imported module."""
+        # First import the module
+        import math
+        
+        callback_executed = []
+        
+        def math_callback(module):
+            callback_executed.append(True)
+            self.assertTrue(hasattr(module, 'pi'))
+        
+        # Register callback for already imported module
+        import_hook.register_module_callback('math', math_callback)
+        
+        # Callback should be executed immediately
+        self.assertTrue(callback_executed)
+        self.assertIn('math', import_hook.triggered)
+    
+    def test_error_in_callback(self):
+        """Test error handling in callbacks."""
+        
+        def error_callback(module):
+            raise ValueError("Test error in callback")
+        
+        # Redirect stderr to capture error message
+        import io
+        from contextlib import redirect_stderr
+        
+        f = io.StringIO()
+        with redirect_stderr(f):
+            # Register callback with intentional error
+            import_hook.register_module_callback('os', error_callback)
+        
+        # Module should still be marked as triggered despite error
+        self.assertIn('os', import_hook.triggered)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduce a mechanism to register callbacks for module imports, allowing immediate execution of these callbacks upon module loading. Include comprehensive unit tests to validate the functionality and error handling of the import hook.