### PR TITLE
Update make_wheel.py 字符串中的引号嵌套冲突

### DIFF
--- a/make_wheel.py
+++ b/make_wheel.py
@@ -89,7 +89,7 @@ def write_probing_wheel(
         "probing": "target/x86_64-unknown-linux-gnu/release/probing",
         "libprobing.so": "target/x86_64-unknown-linux-gnu/release/libprobing.so",
     }.items():
-        zip_info = ZipInfo(f"probing-{metadata["version"]}.data/scripts/{name}")
+        zip_info = ZipInfo(f"probing-{metadata['version']}.data/scripts/{name}")
         zip_info.external_attr = (stat.S_IFREG | 0o755) << 16
         with open(path, "rb") as f:
             contents[zip_info] = f.read()


### PR DESCRIPTION
Update make_wheel.py，修复语法问题，字符串中的引号嵌套冲突